### PR TITLE
fix mkchromecast chunk size config

### DIFF
--- a/files/.config/autostart/mkchromecast.desktop
+++ b/files/.config/autostart/mkchromecast.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Type=Application
 Name=mkchromecast
-Exec=/usr/bin/mkchromecast -p 10291 --encoder-backend ffmpeg -c wav --sample-rate 44100 --chunk-size 1
+Exec=/usr/bin/mkchromecast -p 10291 --encoder-backend ffmpeg -c wav --sample-rate 44100 --chunk-size 4096


### PR DESCRIPTION
Using a better chunk size reduces the laptop's CPU usage and also lower
the playback delay on the chromecast unit.