### PR TITLE
install jack tools

### DIFF
--- a/tasks/install_daw.yml
+++ b/tasks/install_daw.yml
@@ -4,8 +4,11 @@
   dnf:
     name: [
       "ardour6",
+      "Cadence",
+      "jack-audio-connection-kit-dbus",
       "lv2-calf-plugins-gui",
       "lv2-EQ10Q-plugins",
+      "qjackctl",
     ]
     state: present
   when: install_daw | default(false)


### PR DESCRIPTION
In order to be able to route DAW output to specific soundcard.
Use Cadence to start jack and to route the audio output (master) to the
specific soundcard before stating ardour, as ardour may not be able to
start jack with this routing.