### PR TITLE
fix mkchromecast installation (broken deps)

### DIFF
--- a/files/.config/autostart/mkchromecast.desktop
+++ b/files/.config/autostart/mkchromecast.desktop
@@ -1,4 +1,4 @@
 [Desktop Entry]
 Type=Application
 Name=mkchromecast
-Exec=/usr/bin/mkchromecast -p 10291 --encoder-backend ffmpeg -c wav --sample-rate 44100 --chunk-size 4096
+Exec=/usr/local/bin/mkchromecast -p 10291 --encoder-backend ffmpeg -c wav --sample-rate 44100 --chunk-size 4096

--- a/tasks/install_chromecast_audio.yml
+++ b/tasks/install_chromecast_audio.yml
@@ -1,22 +1,52 @@
 ---
-- name: Enable mkchromecast repository
-  become: yes
-  shell: "dnf copr enable -y bugzy/mkchromecast"
-  args:
-    warn: no
-  when: install_chromecast_audio
-  tags:
-    - install_chromecast_audio
-
-- name: Install mkchromecast
+- name: Install mkchromecast deps
   become: yes
   dnf:
     name: [
       "ffmpeg",
-      "mkchromecast",
     ]
     state: present
   when: install_chromecast_audio
+  tags:
+    - install_chromecast_audio
+
+- name: Download mkchromecast sources
+  become: yes
+  unarchive:
+    src: "https://github.com/muammar/mkchromecast/archive/{{ mkchromecast_commit }}.zip"
+    dest: "/usr/local/src"
+    remote_src: yes
+  register: mkchromecast_downloaded
+  when: install_chromecast_audio
+  tags:
+    - install_chromecast_audio
+
+- name: Install mkchromecast python deps
+  become: yes
+  pip:
+    chdir: "/usr/local/src/mkchromecast-{{ mkchromecast_commit }}"
+    requirements: "requirements.txt"
+  when: install_chromecast_audio and mkchromecast_downloaded is changed
+  tags:
+    - install_chromecast_audio
+
+- name: Build mkchromecast package
+  become: yes
+  command: "python setup.py build"
+  args:
+    warn: no
+    chdir: "/usr/local/src/mkchromecast-{{ mkchromecast_commit }}"
+  when: install_chromecast_audio and mkchromecast_downloaded is changed
+  tags:
+    - install_chromecast_audio
+
+- name: Install mkchromecast package
+  become: yes
+  command: "python setup.py install"
+  args:
+    warn: no
+    chdir: "/usr/local/src/mkchromecast-{{ mkchromecast_commit }}"
+  when: install_chromecast_audio and mkchromecast_downloaded is changed
   tags:
     - install_chromecast_audio
 

--- a/vars/localhost.yml.dist
+++ b/vars/localhost.yml.dist
@@ -16,6 +16,8 @@ tuxedo_keyboard_version: 3.0.1
 
 autostart_chromecast_audio: false
 install_chromecast_audio: false
+mkchromecast_commit: fe7bd47fc0368bb70405bb6c55cd94bdb53a7091
+
 install_daw: false
 install_docker: false
 install_game_emulators: false


### PR DESCRIPTION
Mkchromecast uses pychromecast as a dependency, however this packages
has changed its public API. Mkchromecast has fixed the API usage but
hasn't released this fix yet, so we target the fix commit for
installation.

See https://github.com/muammar/mkchromecast/issues/348
See https://github.com/muammar/mkchromecast/pull/332