### PR TITLE
also disable dnf-makecache.timer systemd unit

### DIFF
--- a/tasks/disable_unneeded_services.yml
+++ b/tasks/disable_unneeded_services.yml
@@ -8,7 +8,8 @@
     masked: yes
   with_items:
     - crond
-    - dnf-makecache
+    - dnf-makecache.service
+    - dnf-makecache.timer
     - dkms
     - lvm2-monitor
     - NetworkManager-wait-online


### PR DESCRIPTION
Because the boot was throwing the following error :

```
systemd[1]: dnf-makecache.timer: Refusing to start, unit dnf-makecache.service to trigger not loaded.
systemd[1]: Failed to start dnf makecache --timer.
```