### PR TITLE
Revert/stick to mixxx 2.2.4

### DIFF
--- a/tasks/install_mixxx.yml
+++ b/tasks/install_mixxx.yml
@@ -9,37 +9,7 @@
     state: present
     method: system
   when: install_mixxx | default(false)
-  tags:
-    - install_mixxx
-    - flatpak
-
-- name: Allow installation of specific version
-  become: yes
-  ignore_errors: yes
-  command: "flatpak mask --remove org.mixxx.Mixxx"
-  args:
-    warn: no
-  when: install_mixxx | default(false)
-  tags:
-    - install_mixxx
-    - flatpak
-
-- name: Stick to specific mixxx version
-  become: yes
-  command: "flatpak update -y --commit={{ mixxx_flatpak_commit }} org.mixxx.Mixxx"
-  args:
-    warn: no
-  when: install_mixxx | default(false)
-  tags:
-    - install_mixxx
-    - flatpak
-
-- name: Prevent automatic updates of mixxx
-  become: yes
-  command: "flatpak mask org.mixxx.Mixxx"
-  args:
-    warn: no
-  when: install_mixxx | default(false)
+  register: mixxx_installed
   tags:
     - install_mixxx
     - flatpak

--- a/tasks/install_mixxx.yml
+++ b/tasks/install_mixxx.yml
@@ -9,7 +9,6 @@
     state: present
     method: system
   when: install_mixxx | default(false)
-  register: mixxx_installed
   tags:
     - install_mixxx
     - flatpak

--- a/vars/localhost.yml.dist
+++ b/vars/localhost.yml.dist
@@ -10,9 +10,6 @@ autostart_chromecast_audio: false
 install_chromecast_audio: false
 mkchromecast_commit: fe7bd47fc0368bb70405bb6c55cd94bdb53a7091
 
-# latest flatpak commit for mixxx 2.2.4
-mixxx_flatpak_commit: af3f5768998a2284e7d95123bc90b7977b0c71b0bc40adf1bdebd05b35b7fd2b
-
 install_daw: false
 install_docker: false
 install_game_emulators: false


### PR DESCRIPTION
Even if mixxx 2.3.0 still behaves differently from mixxx 2.2.4 when
handling DVS signal (a bit longer to process), this PR
( https://github.com/nm2107/mixxx-midi-mappings/pull/14 ) made it
usable.