### PR TITLE
install ardour via flatpak

### DIFF
--- a/tasks/install_daw.yml
+++ b/tasks/install_daw.yml
@@ -1,12 +1,22 @@
 ---
-- name: Install DAW
+# Install Ardour via flatpak as it is able to get sound from the
+# external soundcard via this way (Pipewire mess on host ?).
+- name: Install Ardour
+  become: yes
+  flatpak:
+    name: org.ardour.Ardour
+    state: present
+    method: system
+  when: install_daw | default(false)
+  tags:
+    - install_daw
+    - flatpak
+
+- name: Install JACK controls
   become: yes
   dnf:
     name: [
-      "ardour6",
       "Cadence",
-      "lv2-calf-plugins-gui",
-      "lv2-zam-plugins",
       "qjackctl",
     ]
     state: present


### PR DESCRIPTION
As it is able to get sound from external soundcard.
I wasn't able to get (or send) sound anymore to the external soundcard
when using Ardour from the Fedora 34 package manager (dnf). Maybe there
is some Pipewire mess as this version has introduced it.
Using the containerized app w/ flatpak solves this issue at least, but
it could be better to investigate it a bit more in order to use standard
host installation (would be nice to be able to use sound effects installed
by the dnf package manager).