### PR TITLE
fix FreeCAD installation

### DIFF
--- a/tasks/install_cad.yml
+++ b/tasks/install_cad.yml
@@ -1,11 +1,12 @@
 ---
+# Install FreeCAD via flatpak as they provide stable releases and runtimes.
 - name: Install CAD software
   become: yes
-  dnf:
-    name: [
-      "freecad",
-    ]
+  flatpak:
+    name: org.freecadweb.FreeCAD
     state: present
+    method: system
   when: install_cad | default(false)
   tags:
     - install_cad
+    - flatpak


### PR DESCRIPTION
use flatpak to get stables release and runtime instead of using packages
retrieved by dnf which could run on failing python runtime