### PR TITLE
remove `mediawriter` package installation

### DIFF
--- a/vars/localhost.yml.dist
+++ b/vars/localhost.yml.dist
@@ -104,7 +104,6 @@ graphical_apps: [
   "inkscape",
   "k3b",
   "libreoffice",
-  "mediawriter",
   "sound-juicer",
   "steam",
   "thunderbird",


### PR DESCRIPTION
As Gnome's Disk Image Writer does the same and is already installed with
Gnome.