### PR TITLE
install calf audio plugins as a flatpak extension

### DIFF
--- a/tasks/install_daw.yml
+++ b/tasks/install_daw.yml
@@ -11,6 +11,8 @@
   with_items:
     - "org.ardour.Ardour"
     - "org.freedesktop.LinuxAudio.Plugins.Calf"
+    - "org.freedesktop.LinuxAudio.Plugins.LSP/x86_64/21.08"
+    - "org.freedesktop.LinuxAudio.Plugins.x42Plugins/x86_64/21.08"
   tags:
     - install_daw
     - flatpak

--- a/tasks/install_daw.yml
+++ b/tasks/install_daw.yml
@@ -4,10 +4,13 @@
 - name: Install Ardour
   become: yes
   flatpak:
-    name: org.ardour.Ardour
+    name: "{{ item }}"
     state: present
     method: system
   when: install_daw | default(false)
+  with_items:
+    - "org.ardour.Ardour"
+    - "org.freedesktop.LinuxAudio.Plugins.Calf"
   tags:
     - install_daw
     - flatpak


### PR DESCRIPTION
In order to use them with ardour, which is also installed via flatpak.

List available plugins with :

```bash
$ sudo flatpak search -v LinuxAudio
```