### PR TITLE
remove mediawriter installation

### DIFF
--- a/vars/localhost.yml.dist
+++ b/vars/localhost.yml.dist
@@ -49,6 +49,7 @@ packages_to_remove: [
   "hplip",
   "hplip-common",
   "hplip-libs",
+  "mediawriter",
   "plymouth",
   "rhythmbox",
   "tmux",


### PR DESCRIPTION
Completes commit 9c1ffe250cb997f474b62eaaf63a66581345e2a2 by explicitly marking `mediawriter` as uninstalled (was installed by default).