### PR TITLE
install libavcodec-freeworld to enable VLC eac3 audio codec

### DIFF
--- a/vars/localhost.yml.dist
+++ b/vars/localhost.yml.dist
@@ -73,6 +73,7 @@ cli_tools: [
   "gstreamer1",
   "gstreamer1-libav",
   "jq",
+  "libavcodec-freeworld",
   "make",
   "neovim",
   "nethogs",


### PR DESCRIPTION
see https://forums.fedora-fr.org/d/74482-vlc-ne-peut-pas-décoder-le-format--eac3--a52-b-audio-aka-e-ac3/14