### PR TITLE
install qcad

### DIFF
--- a/vars/localhost.yml.dist
+++ b/vars/localhost.yml.dist
@@ -115,6 +115,7 @@ graphical_apps: [
   "inkscape",
   "k3b",
   "libreoffice",
+  "qcad",
   "sound-juicer",
   "steam",
   "thunderbird",


### PR DESCRIPTION
Sometimes LibreCAD fails to display horizontal or vertical lines in .dxf files created with FreeCAD. In order to still be able to open and edit them, also install qcad.

Not available via flathub / flatpak.